### PR TITLE
Assign input's title rather than source to HA's source attribute

### DIFF
--- a/braviatv_psk.py
+++ b/braviatv_psk.py
@@ -259,7 +259,7 @@ class BraviaTVDevice(MediaPlayerDevice):
                     self._program_media_type = playing_info.get(
                         'programMediaType')
                     self._channel_number = playing_info.get('dispNum')
-                    self._source = playing_info.get('source')
+                    self._source = playing_info.get('title')
                     self._content_uri = playing_info.get('uri')
                     self._duration = playing_info.get('durationSec')
                     self._start_date_time = playing_info.get('startDateTime')


### PR DESCRIPTION
For HA's input selector to work properly (show current input state),
the selected input name (media player's `source` attribute) must match
one of the sources listed in `source_list` attribute. It wasn't like
that - the `source_list` listed user-friendly input names (hdmi 1,
component, ...), while `source` listed internal input name (extInput:hdmi).