### PR TITLE
Improve copying instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Work in progress
+
 Sony Bravia component for Home Assistant, which can be used for PIN and Pre-Shared Key (PSK) connection
 
-To get started put /custom_components/braviatv_psk/media_player.py here:
+To get started, make sure you are running Home Assistant 0.92 or never and copy `/custom_components/braviatv_psk/` directory into:
 
-`<config directory>/custom_components/braviatv_psk/media_player.py`
-
-Starting with Home Assistant 0.92 you also need to copy the files `/custom_components/braviatv_psk/__init__.py` and `/custom_components/braviatv_psk/manifest.json` to the same directory.
+`<config directory>/custom_components/braviatv_psk`
 
 **Example configuration file**
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Sony Bravia component for Home Assistant, which can be used for PIN and Pre-Shar
 
 To get started put /custom_components/braviatv_psk/media_player.py here:
 
-<config directory>/custom_components/braviatv_psk/media_player.py
+`<config directory>/custom_components/braviatv_psk/media_player.py`
 
-Starting with Home Assistant 0.92 you also need to copy the file /custom_components/braviatv_psk/__init__.py to <config directory>/custom_components/braviatv_psk/__init__.py and /custom_components/braviatv_psk/manifest.json to <config directory>/custom_components/braviatv_psk/manifest.json
+Starting with Home Assistant 0.92 you also need to copy the files `/custom_components/braviatv_psk/__init__.py` and `/custom_components/braviatv_psk/manifest.json` to the same directory.
 
 **Example configuration file**
 


### PR DESCRIPTION
The part that mentioned `<config directory>` was not rendered when looking at readme.
Make sure it's not parsed by markdown.